### PR TITLE
git clone https -> git clone git

### DIFF
--- a/TriggerInfo/TriggerInfoAnalyzer/README.md
+++ b/TriggerInfo/TriggerInfoAnalyzer/README.md
@@ -110,7 +110,7 @@ Then follow these steps:
 - Obtain the code from git (in sparse mode) and move it to the `src` area:
 
   ```   
-  git clone -b 2011 --no-checkout https://github.com/cms-opendata-analyses/trigger_examples.git
+  git clone -b 2011 --no-checkout git://github.com/cms-opendata-analyses/trigger_examples.git
   cd trigger_examples
   git config core.sparseCheckout true
   echo 'TriggerInfo/TriggerInfoAnalyzer' > .git/info/sparse-checkout


### PR DESCRIPTION
This is needed for the recent changes, see https://githubengineering.com/crypto-removal-notice/ 
@caredg pls have a look and merge. I did not try the second choice (as such it fails but I'm not using ssh key and I did not try further). The same chance is needed for the 2010 branch as well.